### PR TITLE
Configure tgadmin service account during .deb installation

### DIFF
--- a/debian/DEBIAN/conffiles
+++ b/debian/DEBIAN/conffiles
@@ -1,1 +1,2 @@
 /etc/tgadmin/tgadmin.json
+/etc/default/tgadmin

--- a/debian/DEBIAN/postinst
+++ b/debian/DEBIAN/postinst
@@ -4,6 +4,9 @@ set -euo pipefail
 PACKAGE_NAME="tgadmin"
 CONFIG_FILE="/etc/${PACKAGE_NAME}/tgadmin.json"
 SCHEMA_FILE="/usr/share/${PACKAGE_NAME}/db_schema.sql"
+DEFAULTS_FILE="/etc/default/${PACKAGE_NAME}"
+SYSTEMD_DROPIN_DIR="/etc/systemd/system/${PACKAGE_NAME}.service.d"
+SYSTEMD_DROPIN_FILE="${SYSTEMD_DROPIN_DIR}/10-run-as.conf"
 
 DB_NAME="tgadmin"
 DB_USER="tgadmin"
@@ -24,6 +27,63 @@ json_set() {
     jq "$1" "${CONFIG_FILE}" > "${tmp}" && mv "${tmp}" "${CONFIG_FILE}"
 }
 
+resolve_service_identity() {
+    SERVICE_USER="${PACKAGE_NAME}"
+    SERVICE_GROUP="${PACKAGE_NAME}"
+
+    if [ -f "${DEFAULTS_FILE}" ]; then
+        # shellcheck disable=SC1090
+        . "${DEFAULTS_FILE}"
+
+        if [ -n "${TGADMIN_SERVICE_USER:-}" ]; then
+            SERVICE_USER="${TGADMIN_SERVICE_USER}"
+        fi
+        if [ -n "${TGADMIN_SERVICE_GROUP:-}" ]; then
+            SERVICE_GROUP="${TGADMIN_SERVICE_GROUP}"
+        fi
+    fi
+
+    if [ -z "${SERVICE_USER}" ] || [ -z "${SERVICE_GROUP}" ]; then
+        echo "ERROR: TGADMIN_SERVICE_USER and TGADMIN_SERVICE_GROUP must be non-empty." >&2
+        exit 1
+    fi
+}
+
+ensure_service_account() {
+    if ! getent group "${SERVICE_GROUP}" >/dev/null; then
+        groupadd --system "${SERVICE_GROUP}"
+    fi
+
+    if ! id -u "${SERVICE_USER}" >/dev/null 2>&1; then
+        useradd \
+            --system \
+            --gid "${SERVICE_GROUP}" \
+            --no-create-home \
+            --home-dir /nonexistent \
+            --shell /usr/sbin/nologin \
+            "${SERVICE_USER}"
+    fi
+}
+
+configure_systemd_service_user() {
+    if ! command -v systemctl >/dev/null 2>&1; then
+        return
+    fi
+
+    if ! systemctl list-unit-files "${PACKAGE_NAME}.service" >/dev/null 2>&1; then
+        return
+    fi
+
+    mkdir -p "${SYSTEMD_DROPIN_DIR}"
+    cat > "${SYSTEMD_DROPIN_FILE}" <<DROPIN
+[Service]
+User=${SERVICE_USER}
+Group=${SERVICE_GROUP}
+DROPIN
+
+    systemctl daemon-reload || true
+}
+
 case "$1" in
     configure)
         # ----------------------------------------------------------------
@@ -42,6 +102,10 @@ case "$1" in
             echo "       Place tgadmin.json into /etc/tgadmin/ before installing." >&2
             exit 1
         fi
+
+        resolve_service_identity
+        ensure_service_account
+        configure_systemd_service_user
 
         # ----------------------------------------------------------------
         # Data base
@@ -83,8 +147,8 @@ SQL
             echo "         Install it, then run: sudo dpkg-reconfigure ${PACKAGE_NAME}" >&2
         fi
 
-        # Configuration rights — only root and the tgadmin group
-        chown root:${PACKAGE_NAME} "${CONFIG_FILE}" 2>/dev/null || chown root:root "${CONFIG_FILE}"
+        # Configuration rights — only root and the service group
+        chown "root:${SERVICE_GROUP}" "${CONFIG_FILE}" 2>/dev/null || chown root:root "${CONFIG_FILE}"
         chmod 0640 "${CONFIG_FILE}"
         ;;
 esac

--- a/debian/DEBIAN/postrm
+++ b/debian/DEBIAN/postrm
@@ -23,6 +23,8 @@ FLUSH PRIVILEGES;
 SQL
         fi
         rm -f "${CONFIG_FILE}"
+        rm -f "/etc/systemd/system/${PACKAGE_NAME}.service.d/10-run-as.conf"
+        rmdir --ignore-fail-on-non-empty "/etc/systemd/system/${PACKAGE_NAME}.service.d"
         rmdir --ignore-fail-on-non-empty "/etc/${PACKAGE_NAME}"
         ;;
     remove)

--- a/debian/etc/default/tgadmin
+++ b/debian/etc/default/tgadmin
@@ -1,0 +1,11 @@
+# Service identity used by postinst when configuring tgadmin.service.
+#
+# By default package runs daemon as the system account "tgadmin".
+# Override only if you need a different existing or system account.
+#
+# Example:
+# TGADMIN_SERVICE_USER=mybot
+# TGADMIN_SERVICE_GROUP=mybot
+
+TGADMIN_SERVICE_USER=tgadmin
+TGADMIN_SERVICE_GROUP=tgadmin

--- a/debian/lib/systemd/system/tgadmin.service
+++ b/debian/lib/systemd/system/tgadmin.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=TGAdmin Telegram moderation daemon
+After=network-online.target mariadb.service mysql.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/adminhelperd
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
### Motivation
- Avoid hardcoding a local username in the packaged service so the daemon can run without root on other systems. 
- Make the runtime user/group configurable at package install time so the package is portable between hosts. 
- Ensure the package can create a system account when needed and instruct systemd to run the service under that account.

### Description
- Add a packaged systemd unit `debian/lib/systemd/system/tgadmin.service` that does not embed `User`/`Group` so runtime identity can be provided via a drop-in.
- Add `/etc/default/tgadmin` (added as a conffile) with `TGADMIN_SERVICE_USER` and `TGADMIN_SERVICE_GROUP` defaulting to `tgadmin`. 
- Update `debian/DEBIAN/postinst` to read `TGADMIN_SERVICE_USER/GROUP` from `/etc/default/tgadmin`, create the system `group` and `user` if missing, and write a systemd drop-in `/etc/systemd/system/tgadmin.service.d/10-run-as.conf` containing `User=` and `Group=` so the service runs as the non-root account. 
- Adjust config ownership in `postinst` to `chown "root:${SERVICE_GROUP}"` and update `debian/DEBIAN/postrm` purge handling to remove the generated drop-in; add `/etc/default/tgadmin` to `DEBIAN/conffiles`.

### Testing
- Ran a shell syntax check with `bash -n debian/DEBIAN/postinst debian/DEBIAN/postrm` which completed successfully.

