### PR TITLE
Ensure tgadmin runtime log and data dirs are created in postinst

### DIFF
--- a/debian/DEBIAN/postinst
+++ b/debian/DEBIAN/postinst
@@ -7,6 +7,8 @@ SCHEMA_FILE="/usr/share/${PACKAGE_NAME}/db_schema.sql"
 DEFAULTS_FILE="/etc/default/${PACKAGE_NAME}"
 SYSTEMD_DROPIN_DIR="/etc/systemd/system/${PACKAGE_NAME}.service.d"
 SYSTEMD_DROPIN_FILE="${SYSTEMD_DROPIN_DIR}/10-run-as.conf"
+LOG_DIR="/var/log/${PACKAGE_NAME}"
+DATA_DIR="/var/lib/${PACKAGE_NAME}"
 
 DB_NAME="tgadmin"
 DB_USER="tgadmin"
@@ -88,6 +90,11 @@ DROPIN
     systemctl daemon-reload || true
 }
 
+ensure_runtime_directories() {
+    install -d -m 0750 -o "${SERVICE_USER}" -g "${SERVICE_GROUP}" "${LOG_DIR}"
+    install -d -m 0750 -o "${SERVICE_USER}" -g "${SERVICE_GROUP}" "${DATA_DIR}"
+}
+
 case "$1" in
     configure)
         # ----------------------------------------------------------------
@@ -115,6 +122,7 @@ case "$1" in
 
         resolve_service_identity
         ensure_service_account
+        ensure_runtime_directories
         configure_systemd_service_user
 
         # ----------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Prevent the daemon from failing at startup when `/var/log/tgadmin` or `/var/lib/tgadmin` do not exist by creating those runtime directories during package installation and assigning correct owner/group and permissions.

### Description
- Add `LOG_DIR` and `DATA_DIR` variables to `debian/DEBIAN/postinst`.
- Add `ensure_runtime_directories()` which creates the log and data directories with `install -d -m 0750 -o "${SERVICE_USER}" -g "${SERVICE_GROUP}" ...` so the service user owns them and they are not world-readable.
- Call `ensure_runtime_directories` during the `configure` path after `ensure_service_account` and before systemd drop-in configuration.

### Testing
- Ran `bash -n debian/DEBIAN/postinst` to validate the maintainer script syntax, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5ab7dd30083289c5fc98ca514057c)